### PR TITLE
Fixed issue #4 and #5

### DIFF
--- a/epub.py
+++ b/epub.py
@@ -354,7 +354,7 @@ if __name__ == '__main__':
     )
     parser.add_argument('-d', '--dump', action='store_true',
                         help='dump EPUB to text')
-    parser.add_argument('-c', '--cols', action='store', type=int,
+    parser.add_argument('-c', '--cols', action='store', type=int, default=float("+inf"),
                         help='Number of columns to wrap; default is no wrapping.')
     parser.add_argument('EPUB', help='view EPUB')
     args = parser.parse_args()


### PR DESCRIPTION
Issue #4: the dump option failed completely.

```
(venv)[2013-01-04 11:07:03] pavel@addison:~/projects/epub
# ./epub.py -d ~/novel.epub
A Novel
-------




Traceback (most recent call last):
  File "./epub.py", line 362, in <module>
    dump_epub(args.EPUB)
  File "./epub.py", line 178, in dump_epub
    maxcol=screen.getmaxyx()[1]
NameError: global name 'screen' is not defined
(venv)[2013-01-04 11:07:11] pavel@addison:~/projects/epub
```

Issue #5: there was no way to wrap to anything other than 72 columns.
